### PR TITLE
fix: backend not responding

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,4 +5,7 @@ ADD ./src/images /usr/share/nginx/html/images
 ADD ./src/favicon.ico /usr/share/nginx/html/
 COPY ./src/env.js /usr/share/nginx/html/
 COPY ./src/env.template.js /usr/share/nginx/html/
-CMD ["/bin/sh",  "-c",  "envsubst < /usr/share/nginx/html/env.template.js > /usr/share/nginx/html/env.js && exec nginx -g 'daemon off;'"]
+
+COPY ./docker/entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+echo "Starting uni-resolver-frontend"
+
+if [ "$BACKEND_URL" ]
+then
+  echo "Substituting backendUrl with ${BACKEND_URL}"
+  envsubst < /usr/share/nginx/html/env.template.js > /usr/share/nginx/html/env.js
+else
+  echo "Using default URL https://uniresolver.io"
+fi
+
+nginx -g 'daemon off;'

--- a/src/components/ResolverInput.jsx
+++ b/src/components/ResolverInput.jsx
@@ -12,7 +12,7 @@ export class ResolverInput extends Component {
 
 	resolve() {
 		axios
-			.get(window._env_.backendUrl + '1.0/identifiers/' + encodeURIComponent(this.state.input))
+			.get(window._env_.backendUrl + '/1.0/identifiers/' + encodeURIComponent(this.state.input))
 			.then(response => {
 				const didDocument = response.data.didDocument;
 				const resolverMetadata = response.data.resolverMetadata;

--- a/src/env.js
+++ b/src/env.js
@@ -1,3 +1,3 @@
 window._env_ = {
-  backendUrl: "https://uniresolver.io/"
+  backendUrl: "https://uniresolver.io"
 }


### PR DESCRIPTION
- if BACKEND_URL is not provided then the env variable was substituted with empty string
- the entrypoint.sh now checks if BACKEND_URL is set, if not it does not substitute the env variable and the default value specified in the env.js file is used
- prevent bug if BACKEND_URL does not contain trailing slash by adding leading slash to path in ResolverInput.jsx