### PR TITLE
fix: window._env_ variable not set

### DIFF
--- a/src/components/ResolverInput.jsx
+++ b/src/components/ResolverInput.jsx
@@ -11,8 +11,10 @@ export class ResolverInput extends Component {
 	}
 
 	resolve() {
+		let host = 'https://uniresolver.io'
+		if (window._env_ !== undefined && window._env_.backendUrl !== undefined) host = window._env_.backendUrl
 		axios
-			.get(window._env_.backendUrl + '/1.0/identifiers/' + encodeURIComponent(this.state.input))
+			.get( host + '/1.0/identifiers/' + encodeURIComponent(this.state.input))
 			.then(response => {
 				const didDocument = response.data.didDocument;
 				const resolverMetadata = response.data.resolverMetadata;


### PR DESCRIPTION
enable deployment without docker by introducing default host in ResolverInput.jsx